### PR TITLE
Added Issue Templates & Minor README.md Changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug Report
+about: File an issue for a bug
+title: Untitled Bug Report
+labels: bug
+assignees: ''
+
+---
+
+<!-- Don't forget to create a title! -->
+**Description** <!-- What is the problem? -->
+
+**Steps to Reproduce** <!-- The goto way to recreate the bug. -->
+1. 
+2. 
+3. 
+
+**Expected Behavior** <!-- What was supposed to happen? -->
+
+**Screenshots/Videos** <!-- If possible, put any evidence of the bug here. -->
+
+**Additional Context** <!-- How did you come across the bug? -->

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -11,7 +11,6 @@ assignees: ''
 **Related Problem** <!-- If anything, what frustrated you and brought you to make this issue? -->
 
 **Preferred Solution** <!-- How would you like things to change?-->
-A clear and concise description of what you want to happen.
 
 **Alternatives Considered** <!-- Any other ways it could be implemented? -->
 

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -10,7 +10,7 @@ assignees: ''
 <!-- Don't forget to create a title! -->
 **Related Problem** <!-- If anything, what frustrated you and brought you to make this issue? -->
 
-**Preferred Solution** <!-- How would you like things to happen?-->
+**Preferred Solution** <!-- How would you like things to change?-->
 A clear and concise description of what you want to happen.
 
 **Alternatives Considered** <!-- Any other ways it could be implemented? -->

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -14,4 +14,4 @@ assignees: ''
 
 **Alternatives Considered** <!-- Any other ways it could be implemented? -->
 
-**Additional Context** <!-- What were you doing as you thought of this suggestion? -->
+**Additional Context** <!-- What were you doing that made you think about this suggestion? -->

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -2,7 +2,7 @@
 name: Suggestion
 about: Suggest an idea to improve CG
 title: Untitled Suggestion
-labels: enhancement
+labels: suggestion
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/suggestion.md
+++ b/.github/ISSUE_TEMPLATE/suggestion.md
@@ -1,0 +1,18 @@
+---
+name: Suggestion
+about: Suggest an idea to improve CG
+title: Untitled Suggestion
+labels: enhancement
+assignees: ''
+
+---
+
+<!-- Don't forget to create a title! -->
+**Related Problem** <!-- If anything, what frustrated you and brought you to make this issue? -->
+
+**Preferred Solution** <!-- How would you like things to happen?-->
+A clear and concise description of what you want to happen.
+
+**Alternatives Considered** <!-- Any other ways it could be implemented? -->
+
+**Additional Context** <!-- What were you doing as you thought of this suggestion? -->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CivilGamers Bug Reports
 
-This is for CG / CC bug reports. Reports against players should be made in-game using "@admin" or on our [forums](https://civilgamers.com). You can make a bug report by saying "!bugreport" in-game or by going [here](https://github.com/civilgamers/bug-reports/issues/new).
+This is for CG / CC bug reports. Reports against players should be made in-game using `@` or on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here](../../issues/new).
 
 **Sensitive reports should be made to a Server Admin or Super Admin privately.** This includes gamebreaking and abusable bugs. Abusing these bugs without reporting them will lead to a permanent ban, while reporting them may lead to a bug bounty!
+
+[Complaints]: https://www.civilgamers.com/forum/m/18343296/viewforum/3788723

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # CivilGamers Bug Reports
 
-This is for CG / CC bug reports. Reports against players should be made in-game using the `@` sign or made over on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here](../../issues/new).
+This is for CG / CC bug reports. Reports against players should be made in-game using the `@` sign or made over on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here][Bug Report].
 
 **Sensitive reports should be made to a Server Admin or Super Admin privately.** This includes gamebreaking and abusable bugs. Abusing these bugs without reporting them will lead to a permanent ban, while reporting them may lead to a bug bounty!
 
 [Complaints]: https://www.civilgamers.com/forum/m/18343296/viewforum/3788723
+[Bug Report]: ../../issues/new?assignees=&labels=bug&template=bug-report.md&title=Untitled+Bug+Report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CivilGamers Bug Reports
 
-This is for CG / CC bug reports. Reports against players should be made in-game using the `@` sign or made over on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here][Bug Report].
+This is for CG / CC bug reports. Reports against players should be made in-game using the "@" sign or made over on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here][Bug Report].
 
 **Sensitive reports should be made to a Server Admin or Super Admin privately.** This includes gamebreaking and abusable bugs. Abusing these bugs without reporting them will lead to a permanent ban, while reporting them may lead to a bug bounty!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CivilGamers Bug Reports
 
-This is for CG / CC bug reports. Reports against players should be made in-game using `@` or on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here](../../issues/new).
+This is for CG / CC bug reports. Reports against players should be made in-game using the `@` sign or made over on our [forums][Complaints]. You can make a bug report by typing "!bugreport" in-game or by going [here](../../issues/new).
 
 **Sensitive reports should be made to a Server Admin or Super Admin privately.** This includes gamebreaking and abusable bugs. Abusing these bugs without reporting them will lead to a permanent ban, while reporting them may lead to a bug bounty!
 


### PR DESCRIPTION
The issue templates have comments that can only be read when creating/editing them. Markdown comments are made using these `<!-- with text here -->`. <!-- Active example of this in action. -->